### PR TITLE
Selection color

### DIFF
--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@ pre[class*='language-'] ::-moz-selection,
 code[class*='language-']::-moz-selection,
 code[class*='language-'] ::-moz-selection {
   text-shadow: none;
-  background: #011627;
+  background: rgba(29, 59, 83, 0.99);
 }
 
 pre[class*='language-']::selection,
@@ -32,7 +32,7 @@ pre[class*='language-'] ::selection,
 code[class*='language-']::selection,
 code[class*='language-'] ::selection {
   text-shadow: none;
-  background: #011627;
+  background: rgba(29, 59, 83, 0.99);
 }
 
 @media print {


### PR DESCRIPTION
Hi,

thanks for the module :)

I really love this theme and I use this module as my `prism.js` theme.

I notice that the selection color is not obvious.

prism.js:
<img width="191" alt="Fish_Shell___ViPro_s_Note" src="https://user-images.githubusercontent.com/29639463/55004141-a20f7200-5014-11e9-90bc-c10252c49572.png">

I found that sdras use [`#1d3b53`](https://github.com/sdras/night-owl-vscode-theme/blob/bee9b7764aca2821c9d548358c992274a330b844/themes/Night%20Owl-color-theme.json#L84) as the selection background color.

VSCode:
<img width="104" alt="fish_md_—_VdustR_github_io" src="https://user-images.githubusercontent.com/29639463/55001704-2dd2cf80-5010-11e9-9869-21c499ed899c.png">

prism.js(with these changes):
<img width="191" alt="Fish_Shell___ViPro_s_Note" src="https://user-images.githubusercontent.com/29639463/55004079-85733a00-5014-11e9-9335-090f05746841.png">

`rgba(29, 59, 83, 0.99)` that alpha can't be `1` in `::selection`

---

Change selection color to #1d3b53

https://github.com/sdras/night-owl-vscode-theme/blob/bee9b7764aca2821c9d548358c992274a330b844/themes/Night%20Owl-color-theme.json#L84