### PR TITLE
Move fiddly from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
   "license": "MIT",
   "devDependencies": {
     "clean-css": "^4.2.1",
-    "clean-css-cli": "^4.2.1"
+    "clean-css-cli": "^4.2.1",
+    "fiddly": "^0.7.4"
   },
   "dependencies": {
-    "fiddly": "^0.7.4"
+    
   }
 }


### PR DESCRIPTION
When adding this theme to my project I noticed that it added 244 packages. Moving fiddly to devDependencies should resolve this.