### PR TITLE
fixes selection highlight color in light theme

### DIFF
--- a/light-no-italics.css
+++ b/light-no-italics.css
@@ -24,7 +24,7 @@ pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection,
 code[class*="language-"] ::-moz-selection {
   text-shadow: none;
-  background: #fbfbfb;
+  background: #e0e0e0;
 }
 
 pre[class*="language-"]::selection,
@@ -32,7 +32,7 @@ pre[class*="language-"] ::selection,
 code[class*="language-"]::selection,
 code[class*="language-"] ::selection {
   text-shadow: none;
-  background: #fbfbfb;
+  background: #e0e0e0;
 }
 
 @media print {

--- a/light.css
+++ b/light.css
@@ -24,7 +24,7 @@ pre[class*="language-"] ::-moz-selection,
 code[class*="language-"]::-moz-selection,
 code[class*="language-"] ::-moz-selection {
   text-shadow: none;
-  background: #fbfbfb;
+  background: #e0e0e0;
 }
 
 pre[class*="language-"]::selection,
@@ -32,7 +32,7 @@ pre[class*="language-"] ::selection,
 code[class*="language-"]::selection,
 code[class*="language-"] ::selection {
   text-shadow: none;
-  background: #fbfbfb;
+  background: #e0e0e0;
 }
 
 @media print {


### PR DESCRIPTION
The selection for the light theme is not noticeable since it's set to the same color as the background.

Looking at the theme provided by sdras the correct selection background color for the light theme is `#e0e0e0`

`prism.js` with `#e0e0e0` selection color

![image](https://user-images.githubusercontent.com/18050859/124372854-9e3f1100-dc5b-11eb-987e-09807bc239d2.png)

https://github.com/sdras/night-owl-vscode-theme/blob/main/themes/Night%20Owl-Light-color-theme.json#L94